### PR TITLE
Use version var in download URl and bump version

### DIFF
--- a/bottom.rb
+++ b/bottom.rb
@@ -1,9 +1,9 @@
 class Bottom < Formula
   desc "A cross-platform graphical process/system monitor with a customizable interface and a multitude of features."
   homepage "https://github.com/ClementTsang/bottom"
-  url "https://github.com/ClementTsang/bottom/releases/download/0.4.3/bottom_x86_64-apple-darwin.tar.gz"
-  sha256 "19f7d625fc173ac9178aba9098a057fb3254d72a880703c91bf0834f10045ad0"
   version "0.4.4"
+  url "https://github.com/ClementTsang/bottom/releases/download/#{version}/bottom_x86_64-apple-darwin.tar.gz"
+  sha256 "19f7d625fc173ac9178aba9098a057fb3254d72a880703c91bf0834f10045ad0"
 
   def install
     bin.install "btm"


### PR DESCRIPTION
## What

Previously although version was defined in the formula file, it wasn't
being used in the download URL. This change uses the version variable in
the download URL.

This pull request fixes #2

## Why

@ClementTsang thanks for writing bottom and for very kindly also providing a homebrew cask to make installation and updates extremely easy.

This will make it simpler to bump versions in the future by changing them in only a single place. It may also the `brew bump-formula-pr` in future.

## How to review

Check out this this fork and attempt to install bottom

## Who can review

@ClementTsang please