### PR TITLE
Use the version variable in the url

### DIFF
--- a/bottom.rb
+++ b/bottom.rb
@@ -1,9 +1,9 @@
 class Bottom < Formula
   desc "A cross-platform graphical process/system monitor with a customizable interface and a multitude of features."
   homepage "https://github.com/ClementTsang/bottom"
-  url "https://github.com/ClementTsang/bottom/releases/download/0.4.5/bottom_x86_64-apple-darwin.tar.gz"
-  sha256 "966dbd50954714bf2e904f882fe4e3da5c284095e5f89b1e4eba6aa7ed9e8c63"
   version "0.4.5"
+  url "https://github.com/ClementTsang/bottom/releases/download/#{version}/bottom_x86_64-apple-darwin.tar.gz"
+  sha256 "966dbd50954714bf2e904f882fe4e3da5c284095e5f89b1e4eba6aa7ed9e8c63"
 
   def install
     bin.install "btm"


### PR DESCRIPTION
## What

Use the version variable in the url instead of specifying it twice in
the Formula since the download urls follow a standard pattern where the
version is part of the path.

## Why

Reduces the need to change multiple values when updating the formula making it nicely DRY

## How to review

Checkout this branch and attempt to do a `brew cask install bottom` after ensuring that the ClementTsang/homebrew keg has been tapped

## Who can review

@ClementTsang please